### PR TITLE
Allow arbitrary number of kibana config options

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,9 +22,11 @@ default['kibana5']['checksum'] = nil
 
 default['kibana5']['version'] = '5.4.1'
 default['kibana5']['distribution_base_url'] = 'https://artifacts.elastic.co/downloads/kibana'
+default['kibana5']['service_name'] = 'kibana'
 default['kibana5']['service_user'] = 'kibana'
 default['kibana5']['service_group'] = 'kibana'
 
+# config values for kibana.yml
 default['kibana5']['config']['server.port'] = 5601
 default['kibana5']['config']['server.host'] = 'localhost'
 default['kibana5']['config']['elasticsearch.url'] = 'http://localhost:9200'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'anuriq@gmail.com'
 license          'Apache 2.0'
 description      'Installs/Configures kibana 5'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.1.1'
+version          '1.2.0'
 issues_url       'https://github.com/anuriq/chef-kibana5/issues' if respond_to?(:issues_url)
 source_url       'https://github.com/anuriq/chef-kibana5' if respond_to?(:source_url)
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,8 +19,8 @@
 kibana5_install 'kibana'
 
 kibana5_configure 'kibana' do
-  configuration 'server.port' => node['kibana5']['config']['server.port'],
-                'server.host' => node['kibana5']['config']['server.host'],
-                'elasticsearch.url' => node['kibana5']['config']['elasticsearch.url'],
-                'logging.dest' => node['kibana5']['config']['logging.dest']
+  svc_name node['kibana5']['service_name']
+  svc_user node['kibana5']['service_user']
+  svc_group node['kibana5']['service_group']
+  configuration node['kibana5']['config']
 end


### PR DESCRIPTION
Allow arbitrary number of kibana config options to be passed into the configure resources in the default recipe.  This allows you to control the installation config via just attributes, if desired.