### PR TITLE
Add reload option to systemd service

### DIFF
--- a/resources/configure.rb
+++ b/resources/configure.rb
@@ -40,6 +40,7 @@ action :configure do
       user svc_user
       restart 'always'
       exec_start node['kibana5']['exec_file']
+      exec_reload '/bin/kill -HUP $MAINPID'
     end
   end
 


### PR DESCRIPTION
It is needed for proper log rotation as discussed [here](https://discuss.elastic.co/t/kibana-logs-rotation/66441/3)