### PR TITLE
Added logging folder creation

### DIFF
--- a/resources/configure.rb
+++ b/resources/configure.rb
@@ -47,6 +47,15 @@ action :configure do
 
   config = new_resource.configuration
 
+  directory ::File.dirname(config['logging.dest']) do
+    owner svc_user
+    group svc_group
+    mode '0755'
+    recursive true
+    action :create
+    not_if { (config['logging.dest'] == 'stdout') || (config['logging.dest'] == '/var/log/kibana.log') }
+  end
+
   file config['logging.dest'] do
     mode '0644'
     owner svc_user


### PR DESCRIPTION
If creating folder before the kibana5_configure resource call, then kibana user would not exist at that moment and we will have to create directory under any other user and then change rights. If creating directory after kibana5_configure call then the resource will fail because it can't create file in non-existent directory.